### PR TITLE
fix: ensure cooldownPeriod check is done correctly

### DIFF
--- a/packages/contracts/contracts/FeaturedVotingContract.sol
+++ b/packages/contracts/contracts/FeaturedVotingContract.sol
@@ -185,7 +185,7 @@ contract FeaturedVotingContract {
     function _isInCooldownPeriod(bytes calldata publicKey) private view returns (bool) {
         uint256 votingsCount = _min(votings.length, cooldownPeriod);
         for (uint256 i = 0; i < votingsCount; i++) {
-            bytes[] storage featured = featuredByVotingID[votings[i].id];
+            bytes[] storage featured = featuredByVotingID[votings[votings.length - i - 1].id];
             for (uint256 j = 0; j < featured.length; j++) {
                 if (_compareBytes(featured[j], publicKey)) {
                     return true;


### PR DESCRIPTION
The `FeaturedVotingContract` comes with a check in `initializeVoting()` that aims to ensure that the community that the voting is being initialized for, has not been featured previously for #n votings.

This is denoted as the `cooldownPeriod`. If `cooldownPeriod = 1`, this means there needs to be at least one voting which doesn't include the community in question, that came *after* the voting that did.

The internal `_isInCooldownPeriod()` check has a bug which will return false positives for any communiy that has been featured before, regardless of `cooldownPeriod`s value.

When iterating previous votings, the contract actually needs to start with the last one and iterate downwards, however it does the opposite so it will never reach the correct votings to check.

This commit fixes the check and adds two tests to cover the case accordingly.