### PR TITLE
refactor(DeployContracts): mint test tokens for local node

### DIFF
--- a/packages/contracts/script/DeploymentConfig.s.sol
+++ b/packages/contracts/script/DeploymentConfig.s.sol
@@ -87,6 +87,7 @@ contract DeploymentConfig is Script {
             "STT",
             true
         );
+        minimeToken.generateTokens(deployer, 100_000_000 ether);
         vm.stopBroadcast();
 
         return NetworkConfig({

--- a/packages/contracts/test/Directory.t.sol
+++ b/packages/contracts/test/Directory.t.sol
@@ -18,7 +18,7 @@ contract DirectoryTest is Test {
 
     function setUp() public virtual {
         DeployContracts deployment = new DeployContracts();
-        (Directory _directory, VotingContract _votingContract, FeaturedVotingContract _featuredVotingContract,) =
+        (, Directory _directory, VotingContract _votingContract, FeaturedVotingContract _featuredVotingContract) =
             deployment.run();
         directory = _directory;
         votingContract = address(_votingContract);

--- a/packages/contracts/test/FeaturedVotingContract.t.sol
+++ b/packages/contracts/test/FeaturedVotingContract.t.sol
@@ -130,22 +130,16 @@ contract FeaturedVotingContractTest is Test {
     function setUp() public virtual {
         DeployContracts deployment = new DeployContracts();
         (
+            MiniMeToken _mockSNT,
             Directory _directory,
             VotingContract _votingContract,
-            FeaturedVotingContract _featuredVotingContract,
-            DeploymentConfig deploymentConfig
+            FeaturedVotingContract _featuredVotingContract
         ) = deployment.run();
 
-        (
-            ,
-            ,
-            ,
-            uint32 _featuredVotingLengthInSeconds,
-            uint32 _featuredVotingVerificationLengthInSeconds,
-            ,
-            ,
-            address _mockSNT
-        ) = deploymentConfig.activeNetworkConfig();
+        DeploymentConfig deploymentConfig = deployment.getDeploymentConfig();
+
+        (,,, uint32 _featuredVotingLengthInSeconds, uint32 _featuredVotingVerificationLengthInSeconds,,,) =
+            deploymentConfig.activeNetworkConfig();
 
         votingContract = address(_votingContract);
         featuredVotingLengthInSeconds = _featuredVotingLengthInSeconds;
@@ -155,7 +149,7 @@ contract FeaturedVotingContractTest is Test {
         featuredVotingContract = _featuredVotingContract;
         directoryContract = _directory;
 
-        mockSNT = MiniMeToken(payable(_mockSNT));
+        mockSNT = _mockSNT;
         deployer = deploymentConfig.deployer();
 
         vm.prank(deployer);

--- a/packages/contracts/test/VotingContract.t.sol
+++ b/packages/contracts/test/VotingContract.t.sol
@@ -106,18 +106,11 @@ contract VotingContractTest is Test {
 
     function setUp() public virtual {
         DeployContracts deployment = new DeployContracts();
-        (Directory _directory, VotingContract _votingContract,, DeploymentConfig deploymentConfig) = deployment.run();
+        (MiniMeToken _mockSNT, Directory _directory, VotingContract _votingContract,) = deployment.run();
+        DeploymentConfig deploymentConfig = deployment.getDeploymentConfig();
 
-        (
-            uint32 _votingLengthInSeconds,
-            uint32 _votingVerificationLengthInSeconds,
-            uint32 _timeBetweenVoting,
-            ,
-            ,
-            ,
-            ,
-            address tokenAddress
-        ) = deploymentConfig.activeNetworkConfig();
+        (uint32 _votingLengthInSeconds, uint32 _votingVerificationLengthInSeconds, uint32 _timeBetweenVoting,,,,,) =
+            deploymentConfig.activeNetworkConfig();
 
         timeBetweenVoting = _timeBetweenVoting;
         votingContract = _votingContract;
@@ -125,7 +118,7 @@ contract VotingContractTest is Test {
         votingLength = _votingLengthInSeconds;
         votingVerificationLength = _votingVerificationLengthInSeconds;
         votingWithVerificationLength = votingLength + votingVerificationLength;
-        mockSNT = MiniMeToken(payable(tokenAddress));
+        mockSNT = _mockSNT;
         deployer = deploymentConfig.deployer();
 
         vm.prank(deployer);


### PR DESCRIPTION
This commit addresses the issue that, when testing the contracts on a local node, the test (deployer) account does not have any tokens to use the voting contracts with.

This is fixed by minting tokens as the deployer of the mock SNT contract.

The commit also adds the expect SNT contract instance as a return value of the deploy function, ensuring its address is rendered in stdout when running the script.

Adding it to the returned tuple however caused a "stack too deep" error, which is why we had to remove one value from the returned tuple.

Since the `DeploymentConfig` contract instance address is irrelevant for actual deployments, I've removed it from `DeployContracts.run()` and added an additional function to retrieve it within tests.