### PR TITLE
fix: adjust remappings and rpc configs

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -24,7 +24,7 @@
 [etherscan]
   #goerli = { key = "${API_KEY_ETHERSCAN}" }
   #mainnet = { key = "${API_KEY_ETHERSCAN}" }
-  #optimism = { key = "${API_KEY_OPTIMISTIC_ETHERSCAN}" }
+  optimism = { key = "${API_KEY_OPTIMISTIC_ETHERSCAN}" }
   #sepolia = { key = "${API_KEY_ETHERSCAN}" }
 
 [fmt]
@@ -41,6 +41,6 @@
   #goerli = "https://goerli.infura.io/v3/${API_KEY_INFURA}"
   localhost = "http://localhost:8545"
   #mainnet = "https://eth-mainnet.g.alchemy.com/v2/${API_KEY_ALCHEMY}"
-  #optimism = "https://optimism-mainnet.infura.io/v3/${API_KEY_INFURA}"
+  optimism = "https://opt-mainnet.g.alchemy.com/v2/${API_KEY_OPTIMISM}"
   #sepolia = "https://sepolia.infura.io/v3/${API_KEY_INFURA}"
 

--- a/packages/contracts/remappings.txt
+++ b/packages/contracts/remappings.txt
@@ -1,5 +1,5 @@
 forge-std/=lib/forge-std/src/
-@openzeppelin/=lib/openzeppelin-contracts/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
 @vacp2p/minime/contracts/=lib/minime/contracts/
 
 


### PR DESCRIPTION
This slightly adjust the remappings config to be a bit more specific as otherwise there was an issue with verifying contracts on chain explorers.

It also enables RPC configs for optimism.