### PR TITLE
chore: update "@status-im/js" dependency to version 0.6.7

### DIFF
--- a/packages/DApp/package.json
+++ b/packages/DApp/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@libp2p/bootstrap": "^9.0.10",
-    "@status-im/js": "0.6.6",
+    "@status-im/js": "0.6.7",
     "@usedapp/core": "^1.2.8",
     "@waku/core": "^0.0.27",
     "@waku/sdk": "^0.0.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,10 +2570,10 @@
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
-"@status-im/js@0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@status-im/js/-/js-0.6.6.tgz#9dc30a6034ea2772fef097e16fd5e68a36d439c0"
-  integrity sha512-oikBEu61EMlSTfErYMBTgLjXs1R48/5GIxWE+lZ0T4g17Bjso8C03hjrvSrqhzy9gGTaT2Ueja8ePmkWe+7lGw==
+"@status-im/js@0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@status-im/js/-/js-0.6.7.tgz#cd262246017d160d3308fa5443d22dc2f8a9e996"
+  integrity sha512-r0T99tegSIINbhBPiFmE743vBSItCAru4/c1em4bKxSpqvnCyPiEXa7w+3stKYUczrWJXtFdDZF/v973+v4a7Q==
   dependencies:
     "@bufbuild/protobuf" "1.4.2"
     "@libp2p/bootstrap" "^9.0.10"


### PR DESCRIPTION
## why

- https://github.com/status-im/status-web/pull/576